### PR TITLE
Makesure to use web3 1.0.0-beta.37 because web3 1.0.0-beta.38 has bug

### DIFF
--- a/02_web3_connect_to_local_rpc_and_access_contract/package.json
+++ b/02_web3_connect_to_local_rpc_and_access_contract/package.json
@@ -22,6 +22,6 @@
     "webpack-cli": "^3.2.1"
   },
   "dependencies": {
-    "web3": "^1.0.0-beta.37"
+    "web3": "1.0.0-beta.37"
   }
 }

--- a/03_web3_sending_dxn/package.json
+++ b/03_web3_sending_dxn/package.json
@@ -22,6 +22,6 @@
     "webpack-cli": "^3.2.1"
   },
   "dependencies": {
-    "web3": "^1.0.0-beta.37"
+    "web3": "1.0.0-beta.37"
   }
 }

--- a/04_deploy_to_testnet/package.json
+++ b/04_deploy_to_testnet/package.json
@@ -23,6 +23,6 @@
     "webpack-cli": "^3.2.1"
   },
   "dependencies": {
-    "web3": "^1.0.0-beta.37"
+    "web3": "1.0.0-beta.37"
   }
 }

--- a/05_read_from_ws_write_from_http/package.json
+++ b/05_read_from_ws_write_from_http/package.json
@@ -23,6 +23,6 @@
     "webpack-cli": "^3.2.1"
   },
   "dependencies": {
-    "web3": "^1.0.0-beta.37"
+    "web3": "1.0.0-beta.37"
   }
 }

--- a/06_get_past_events/package.json
+++ b/06_get_past_events/package.json
@@ -23,6 +23,6 @@
     "webpack-cli": "^3.2.1"
   },
   "dependencies": {
-    "web3": "^1.0.0-beta.37"
+    "web3": "1.0.0-beta.37"
   }
 }

--- a/07_sync_contract_data_by_polling/package.json
+++ b/07_sync_contract_data_by_polling/package.json
@@ -23,6 +23,6 @@
     "webpack-cli": "^3.2.1"
   },
   "dependencies": {
-    "web3": "^1.0.0-beta.37"
+    "web3": "1.0.0-beta.37"
   }
 }

--- a/09_sync_contract_data_by_observing_transactions/package.json
+++ b/09_sync_contract_data_by_observing_transactions/package.json
@@ -24,6 +24,6 @@
   },
   "dependencies": {
     "ethereum-input-data-decoder": "0.0.13",
-    "web3": "^1.0.0-beta.37"
+    "web3": "1.0.0-beta.37"
   }
 }

--- a/10_contract_migration_data_separation_pattern/package.json
+++ b/10_contract_migration_data_separation_pattern/package.json
@@ -24,6 +24,6 @@
   },
   "dependencies": {
     "ethereum-input-data-decoder": "0.0.13",
-    "web3": "^1.0.0-beta.37"
+    "web3": "1.0.0-beta.37"
   }
 }

--- a/11_contract_migration_by_delegatecall_proxy_pattern/package.json
+++ b/11_contract_migration_by_delegatecall_proxy_pattern/package.json
@@ -24,6 +24,6 @@
   },
   "dependencies": {
     "ethereum-input-data-decoder": "0.0.13",
-    "web3": "^1.0.0-beta.37"
+    "web3": "1.0.0-beta.37"
   }
 }

--- a/12_IPFS_picture_upload/package.json
+++ b/12_IPFS_picture_upload/package.json
@@ -25,6 +25,6 @@
   "dependencies": {
     "ipfs-http-client": "^29.0.0",
     "pull-file-reader": "^1.0.2",
-    "web3": "^1.0.0-beta.37"
+    "web3": "1.0.0-beta.37"
   }
 }


### PR DESCRIPTION
Today I find out that build:webapp get failed. 
If I execute node program that use web3  will also failed too. 

Because web3 release 1.0.0-beta.38 14 hours ago. 
(https://github.com/ethereum/web3.js/)
When "web3" : "1.0.0-beta.37" in package.json, The action "npm install" will automatically install 1.0.0-beta.38 today.  

Because we want to avoid the bug of web3 1.0.0-beta.38. so we rewrite package.sjon from ^1.0.0-beta.37 into 1.0.0-beta.37.  We can make sure the project can running well in these fiew days.

 
